### PR TITLE
FP88 - Sort Guides by Date\Rating

### DIFF
--- a/src/app/(admin)/new_dashboard/guides/components/SearchBar/index.tsx
+++ b/src/app/(admin)/new_dashboard/guides/components/SearchBar/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import Autocomplete from "@mui/material/Autocomplete";
+import { SortCriteria, sortOptions } from "../../types";
 
 type Props = {
   searchQuery: string;
@@ -16,9 +17,10 @@ type Props = {
   selectedTag: string;
   onTagChange: (e: React.ChangeEvent<{}>, value: string | null) => void;
   categories: string[];
-  sortCriteria: "rating" | "date";
+  sortCriteria: SortCriteria;
   handleSortChange: (e: SelectChangeEvent<string>) => void;
 };
+
 
 const SearchBar = ({ 
   searchQuery, 
@@ -62,12 +64,14 @@ const SearchBar = ({
     </FormControl>
     <FormControl variant="outlined" sx={{ ml: 2, minWidth: 150 }}>
       <Select
-        value={sortCriteria}
         onChange={handleSortChange}
         displayEmpty
       >
-        <MenuItem value="rating">Sort by Rating</MenuItem>
-        <MenuItem value="date">Sort by Date</MenuItem>
+        {sortOptions.map((option) => (
+          <MenuItem key={option} value={option}>
+            Sort by {option}
+          </MenuItem>
+        ))}
       </Select>
     </FormControl>
   </Box>

--- a/src/app/(admin)/new_dashboard/guides/components/SearchBar/index.tsx
+++ b/src/app/(admin)/new_dashboard/guides/components/SearchBar/index.tsx
@@ -1,4 +1,12 @@
-import { TextField, InputAdornment, Box, FormControl } from "@mui/material";
+import { 
+  TextField, 
+  InputAdornment, 
+  Box, 
+  FormControl, 
+  Select, 
+  MenuItem,
+  SelectChangeEvent
+} from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import Autocomplete from "@mui/material/Autocomplete";
 
@@ -8,9 +16,19 @@ type Props = {
   selectedTag: string;
   onTagChange: (e: React.ChangeEvent<{}>, value: string | null) => void;
   categories: string[];
+  sortCriteria: "rating" | "date";
+  handleSortChange: (e: SelectChangeEvent<string>) => void;
 };
 
-const SearchBar = ({ searchQuery, onSearchChange, selectedTag, onTagChange, categories }: Props) => (
+const SearchBar = ({ 
+  searchQuery, 
+  onSearchChange, 
+  selectedTag, 
+  onTagChange, 
+  categories, 
+  sortCriteria, 
+  handleSortChange 
+}: Props) => (
   <Box display="flex" alignItems="center" justifyContent="space-between">
     <TextField
       fullWidth
@@ -41,6 +59,16 @@ const SearchBar = ({ searchQuery, onSearchChange, selectedTag, onTagChange, cate
         isOptionEqualToValue={(option, value) => option === value}
         getOptionLabel={(option) => option}
       />
+    </FormControl>
+    <FormControl variant="outlined" sx={{ ml: 2, minWidth: 150 }}>
+      <Select
+        value={sortCriteria}
+        onChange={handleSortChange}
+        displayEmpty
+      >
+        <MenuItem value="rating">Sort by Rating</MenuItem>
+        <MenuItem value="date">Sort by Date</MenuItem>
+      </Select>
     </FormControl>
   </Box>
 );

--- a/src/app/(admin)/new_dashboard/guides/hooks/sortGuides.ts
+++ b/src/app/(admin)/new_dashboard/guides/hooks/sortGuides.ts
@@ -1,0 +1,14 @@
+import { Guide } from "@/api/types/Guide";
+
+export const sortByCriteria = (guides: Guide[], sortCriteria: string): Guide[] => {
+    return guides.sort((a, b) => {
+        if (sortCriteria === "rating") {
+            const avgRatingA = a.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
+            const avgRatingB = b.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
+            return avgRatingB - avgRatingA;
+        } else if (sortCriteria === "date") {
+            return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+        }
+        return 0;
+    });
+};

--- a/src/app/(admin)/new_dashboard/guides/hooks/sortGuides.ts
+++ b/src/app/(admin)/new_dashboard/guides/hooks/sortGuides.ts
@@ -1,13 +1,14 @@
 import { Guide } from "@/api/types/Guide";
+import { calculateAvgRating } from "@/util/calculateAvgRating";
 
 export const sortByCriteria = (guides: Guide[], sortCriteria: string): Guide[] => {
-    return guides.sort((a, b) => {
+    return guides.sort((guide1, guide2) => {
         if (sortCriteria === "rating") {
-            const avgRatingA = a.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
-            const avgRatingB = b.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
+            const avgRatingA = calculateAvgRating(guide1);
+            const avgRatingB = calculateAvgRating(guide2);
             return avgRatingB - avgRatingA;
         } else if (sortCriteria === "date") {
-            return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+            return new Date(guide2.createdAt).getTime() - new Date(guide1.createdAt).getTime();
         }
         return 0;
     });

--- a/src/app/(admin)/new_dashboard/guides/hooks/useSearchGuides.ts
+++ b/src/app/(admin)/new_dashboard/guides/hooks/useSearchGuides.ts
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { Guide } from "@/api/types/Guide";
+import { SelectChangeEvent } from "@mui/material";
 
 export const useSearchGuides = (initialGuides: Guide[]) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTag, setSelectedTag] = useState("All");
+  const [sortCriteria, setSortCriteria] = useState<"rating" | "date">("rating");
 
   const filteredGuides = initialGuides.filter((guide) => {
     const matchesQuery = guide.title
@@ -12,7 +14,16 @@ export const useSearchGuides = (initialGuides: Guide[]) => {
     const matchesTag =
       selectedTag === "All" || guide.categories.includes(selectedTag);
     return matchesQuery && matchesTag;
-  });
+  })
+    .sort((a, b) => {
+      if (sortCriteria === "rating") {
+        const avgRatingA = a.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
+        const avgRatingB = b.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
+        return avgRatingB - avgRatingA;
+      } else {
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      }
+    });
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
@@ -22,11 +33,17 @@ export const useSearchGuides = (initialGuides: Guide[]) => {
     setSelectedTag(value || "All");
   };
 
+  const handleSortChange = (event: SelectChangeEvent<string> ) => {
+    setSortCriteria(event.target.value as "rating" | "date");
+  };
+
   return {
     searchQuery,
     selectedTag,
+    sortCriteria,
     filteredGuides,
     handleSearchChange,
     handleTagChange,
+    handleSortChange,
   };
 };

--- a/src/app/(admin)/new_dashboard/guides/hooks/useSearchGuides.ts
+++ b/src/app/(admin)/new_dashboard/guides/hooks/useSearchGuides.ts
@@ -1,29 +1,25 @@
 import { useState } from "react";
 import { Guide } from "@/api/types/Guide";
 import { SelectChangeEvent } from "@mui/material";
+import { SortCriteria } from "../types";
+import { sortByCriteria } from "./sortGuides";
 
 export const useSearchGuides = (initialGuides: Guide[]) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTag, setSelectedTag] = useState("All");
-  const [sortCriteria, setSortCriteria] = useState<"rating" | "date">("rating");
+  const [sortCriteria, setSortCriteria] = useState<SortCriteria>("rating");
 
-  const filteredGuides = initialGuides.filter((guide) => {
-    const matchesQuery = guide.title
-      .toLowerCase()
-      .includes(searchQuery.toLowerCase());
-    const matchesTag =
-      selectedTag === "All" || guide.categories.includes(selectedTag);
-    return matchesQuery && matchesTag;
-  })
-    .sort((a, b) => {
-      if (sortCriteria === "rating") {
-        const avgRatingA = a.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
-        const avgRatingB = b.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
-        return avgRatingB - avgRatingA;
-      } else {
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-      }
-    });
+  const filteredGuides = sortByCriteria(
+    initialGuides.filter((guide) => {
+      const matchesQuery = guide.title
+        .toLowerCase()
+        .includes(searchQuery.toLowerCase());
+      const matchesTag =
+        selectedTag === "All" || guide.categories.includes(selectedTag);
+      return matchesQuery && matchesTag;
+    }),
+    sortCriteria
+  );
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
@@ -34,7 +30,7 @@ export const useSearchGuides = (initialGuides: Guide[]) => {
   };
 
   const handleSortChange = (event: SelectChangeEvent<string> ) => {
-    setSortCriteria(event.target.value as "rating" | "date");
+    setSortCriteria(event.target.value as SortCriteria);
   };
 
   return {

--- a/src/app/(admin)/new_dashboard/guides/hooks/useSearchGuides.ts
+++ b/src/app/(admin)/new_dashboard/guides/hooks/useSearchGuides.ts
@@ -9,17 +9,16 @@ export const useSearchGuides = (initialGuides: Guide[]) => {
   const [selectedTag, setSelectedTag] = useState("All");
   const [sortCriteria, setSortCriteria] = useState<SortCriteria>("rating");
 
-  const filteredGuides = sortByCriteria(
-    initialGuides.filter((guide) => {
-      const matchesQuery = guide.title
-        .toLowerCase()
-        .includes(searchQuery.toLowerCase());
-      const matchesTag =
-        selectedTag === "All" || guide.categories.includes(selectedTag);
-      return matchesQuery && matchesTag;
-    }),
-    sortCriteria
-  );
+  const filteredGuides = initialGuides.filter((guide) => {
+    const matchesQuery = guide.title
+      .toLowerCase()
+      .includes(searchQuery.toLowerCase());
+    const matchesTag =
+      selectedTag === "All" || guide.categories.includes(selectedTag);
+    return matchesQuery && matchesTag;
+  });
+
+  const sortedAndFilteredGuides = sortByCriteria(filteredGuides, sortCriteria);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
@@ -37,7 +36,7 @@ export const useSearchGuides = (initialGuides: Guide[]) => {
     searchQuery,
     selectedTag,
     sortCriteria,
-    filteredGuides,
+    filteredGuides: sortedAndFilteredGuides,
     handleSearchChange,
     handleTagChange,
     handleSortChange,

--- a/src/app/(admin)/new_dashboard/guides/page.tsx
+++ b/src/app/(admin)/new_dashboard/guides/page.tsx
@@ -12,7 +12,15 @@ const GuidesListPage = () => {
   const { guides, isLoadingGuides, guidesError, isGuidesError, isGuidesSuccess } = useGuideItems();
   const { categories, error: issuesError, isLoading: isLoadingIssues } = useCategories();
 
-  const { searchQuery, selectedTag, filteredGuides, handleSearchChange, handleTagChange } =
+  const { 
+    searchQuery, 
+    selectedTag, 
+    filteredGuides, 
+    sortCriteria, 
+    handleSearchChange, 
+    handleTagChange, 
+    handleSortChange 
+  } =
     useSearchGuides(guides);
 
   return (
@@ -34,6 +42,8 @@ const GuidesListPage = () => {
                   selectedTag={selectedTag}
                   onTagChange={handleTagChange}
                   categories={["All", ...categories]}  
+                  sortCriteria={sortCriteria}
+                  handleSortChange={handleSortChange}
                 />
               </Box>
               <GuideList guideItems={filteredGuides} />

--- a/src/app/(admin)/new_dashboard/guides/types/index.ts
+++ b/src/app/(admin)/new_dashboard/guides/types/index.ts
@@ -5,3 +5,6 @@ export type Guide = {
   likes: number;
   dislikes: number;
 };
+
+export type SortCriteria = "rating" | "date";
+export const sortOptions = ["rating", "date"];

--- a/src/util/calculateAvgRating.ts
+++ b/src/util/calculateAvgRating.ts
@@ -1,0 +1,5 @@
+import { Guide } from "@/api/types/Guide";
+
+export const calculateAvgRating = (guide: Guide): number => {
+  return guide.reviews?.reduce((acc, review) => acc + review.rating, 0) ?? 1;
+};


### PR DESCRIPTION
## Task link from JIRA:
https://mssplinter10-1711638164183.atlassian.net/jira/software/projects/FP/boards/6?selectedIssue=FP-88

### Summary
This pull request introduces sorting functionality to the SearchBar component.
It refactors the useSearchGuides hook to include this new feature.
Now, Guides can be sorted by: **_Rating\Date_**.

## Description:
- Refactor: Use sorting functionality and an array of sorting options to sort the guides array we get from the hook (86bffa1)
- Refactor: Use _hook_ `useSearchGuides` to include sorting functionality (81a3fc2)
- feat: Add `sortGuides.ts` file for sorting functionality (0af794d)
- feat: Add `SortCriteria` _Type_ and `SortOptions` _Array_ to Guide types (ce01ac7)
- feat: Add sorting functionality to `SearchBar` _component_ (9a013ea)
- Feat: Refactor `useSearchGuides` _hook_ to include sorting functionality (f992352, daa4ed4)

## Code Owners:
@TomerMiz10